### PR TITLE
add extra swap tenors

### DIFF
--- a/man/DiscountCurve.Rd
+++ b/man/DiscountCurve.Rd
@@ -38,10 +38,17 @@ DiscountCurve(params, tsQuotes, times, legparams)
       \code{d1y}  \tab 1-year deposit rate\cr
       \code{s2y}  \tab 2-year swap rate\cr
       \code{s3y}  \tab 3-year swap rate\cr
+      \code{s4y}  \tab 4-year swap rate\cr
       \code{s5y}  \tab 5-year swap rate\cr
+      \code{s6y}  \tab 6-year swap rate\cr
+      \code{s7y}  \tab 7-year swap rate\cr
+      \code{s8y}  \tab 8-year swap rate\cr
+      \code{s9y}  \tab 9-year swap rate\cr
       \code{s10y} \tab 10-year swap rate\cr
+      \code{s12y} \tab 12-year swap rate\cr
       \code{s15y} \tab 15-year swap rate\cr
       \code{s20y} \tab 20-year swap rate\cr
+      \code{s25y}  \tab 25-year swap rate\cr
       \code{s30y} \tab 30-year swap rate\cr
       \code{s40y} \tab 40-year swap rate\cr
       \code{s50y} \tab 50-year swap rate\cr

--- a/src/curves.cpp
+++ b/src/curves.cpp
@@ -35,10 +35,17 @@ ObservableDB::ObservableDB() {
     db_["d1y"] = new RQLObservable(RQLDeposit, 1, 0, QuantLib::Years);
     db_["s2y"] = new RQLObservable(RQLSwap, 2, 0, QuantLib::Years);
     db_["s3y"] = new RQLObservable(RQLSwap, 3, 0, QuantLib::Years);
+    db_["s4y"] = new RQLObservable(RQLSwap, 4, 0, QuantLib::Years);
     db_["s5y"] = new RQLObservable(RQLSwap, 5, 0, QuantLib::Years);
+    db_["s6y"] = new RQLObservable(RQLSwap, 6, 0, QuantLib::Years);
+    db_["s7y"] = new RQLObservable(RQLSwap, 7, 0, QuantLib::Years);
+    db_["s8y"] = new RQLObservable(RQLSwap, 8, 0, QuantLib::Years);
+    db_["s9y"] = new RQLObservable(RQLSwap, 9, 0, QuantLib::Years);
     db_["s10y"] = new RQLObservable(RQLSwap, 10, 0, QuantLib::Years);
+    db_["s12y"] = new RQLObservable(RQLSwap, 12, 0, QuantLib::Years);
     db_["s15y"] = new RQLObservable(RQLSwap, 15, 0, QuantLib::Years);
     db_["s20y"] = new RQLObservable(RQLSwap, 20, 0, QuantLib::Years);
+    db_["s25y"] = new RQLObservable(RQLSwap, 25, 0, QuantLib::Years);
     db_["s30y"] = new RQLObservable(RQLSwap, 30, 0, QuantLib::Years);
     db_["s40y"] = new RQLObservable(RQLSwap, 40, 0, QuantLib::Years);
     db_["s50y"] = new RQLObservable(RQLSwap, 50, 0, QuantLib::Years);


### PR DESCRIPTION
I'm using the yield curve data published by Markit (see http://www.cdsmodel.com/assets/cds-model/docs/Interest%20Rate%20Curve%20-%20XML%20Specifications.pdf) and they provide additional swap tenors.