### PR TITLE
Cleanup enums

### DIFF
--- a/inst/include/RQuantLib_RcppExports.h
+++ b/inst/include/RQuantLib_RcppExports.h
@@ -24,11 +24,11 @@ namespace RQuantLib {
         }
     }
 
-    inline double zeroPriceByYieldEngine(double yield, double faceAmount, double dayCounter, double frequency, double businessDayConvention, double compound, QuantLib::Date maturityDate, QuantLib::Date issueDate) {
+    inline double zeroPriceByYieldEngine(double yield, double faceAmount, int dayCounter, int frequency, int businessDayConvention, int compound, QuantLib::Date maturityDate, QuantLib::Date issueDate) {
         typedef SEXP(*Ptr_zeroPriceByYieldEngine)(SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP);
         static Ptr_zeroPriceByYieldEngine p_zeroPriceByYieldEngine = NULL;
         if (p_zeroPriceByYieldEngine == NULL) {
-            validateSignature("double(*zeroPriceByYieldEngine)(double,double,double,double,double,double,QuantLib::Date,QuantLib::Date)");
+            validateSignature("double(*zeroPriceByYieldEngine)(double,double,int,int,int,int,QuantLib::Date,QuantLib::Date)");
             p_zeroPriceByYieldEngine = (Ptr_zeroPriceByYieldEngine)R_GetCCallable("RQuantLib", "RQuantLib_zeroPriceByYieldEngine");
         }
         RObject __result;
@@ -43,11 +43,11 @@ namespace RQuantLib {
         return Rcpp::as<double >(__result);
     }
 
-    inline double zeroYieldByPriceEngine(double price, double faceAmount, double dayCounter, double frequency, double businessDayConvention, double compound, QuantLib::Date maturityDate, QuantLib::Date issueDate) {
+    inline double zeroYieldByPriceEngine(double price, double faceAmount, int dayCounter, int frequency, int businessDayConvention, int compound, QuantLib::Date maturityDate, QuantLib::Date issueDate) {
         typedef SEXP(*Ptr_zeroYieldByPriceEngine)(SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP);
         static Ptr_zeroYieldByPriceEngine p_zeroYieldByPriceEngine = NULL;
         if (p_zeroYieldByPriceEngine == NULL) {
-            validateSignature("double(*zeroYieldByPriceEngine)(double,double,double,double,double,double,QuantLib::Date,QuantLib::Date)");
+            validateSignature("double(*zeroYieldByPriceEngine)(double,double,int,int,int,int,QuantLib::Date,QuantLib::Date)");
             p_zeroYieldByPriceEngine = (Ptr_zeroYieldByPriceEngine)R_GetCCallable("RQuantLib", "RQuantLib_zeroYieldByPriceEngine");
         }
         RObject __result;
@@ -62,11 +62,11 @@ namespace RQuantLib {
         return Rcpp::as<double >(__result);
     }
 
-    inline double fixedRateBondYieldByPriceEngine(double settlementDays, double price, std::string cal, double faceAmount, double businessDayConvention, double compound, double redemption, double dayCounter, double frequency, QuantLib::Date maturityDate, QuantLib::Date issueDate, QuantLib::Date effectiveDate, std::vector<double> rates) {
+    inline double fixedRateBondYieldByPriceEngine(double settlementDays, double price, std::string cal, double faceAmount, int businessDayConvention, int compound, double redemption, int dayCounter, int frequency, QuantLib::Date maturityDate, QuantLib::Date issueDate, QuantLib::Date effectiveDate, std::vector<double> rates) {
         typedef SEXP(*Ptr_fixedRateBondYieldByPriceEngine)(SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP);
         static Ptr_fixedRateBondYieldByPriceEngine p_fixedRateBondYieldByPriceEngine = NULL;
         if (p_fixedRateBondYieldByPriceEngine == NULL) {
-            validateSignature("double(*fixedRateBondYieldByPriceEngine)(double,double,std::string,double,double,double,double,double,double,QuantLib::Date,QuantLib::Date,QuantLib::Date,std::vector<double>)");
+            validateSignature("double(*fixedRateBondYieldByPriceEngine)(double,double,std::string,double,int,int,double,int,int,QuantLib::Date,QuantLib::Date,QuantLib::Date,std::vector<double>)");
             p_fixedRateBondYieldByPriceEngine = (Ptr_fixedRateBondYieldByPriceEngine)R_GetCCallable("RQuantLib", "RQuantLib_fixedRateBondYieldByPriceEngine");
         }
         RObject __result;
@@ -81,11 +81,11 @@ namespace RQuantLib {
         return Rcpp::as<double >(__result);
     }
 
-    inline double fixedRateBondPriceByYieldEngine(double settlementDays, double yield, std::string cal, double faceAmount, double businessDayConvention, double compound, double redemption, double dayCounter, double frequency, QuantLib::Date maturityDate, QuantLib::Date issueDate, QuantLib::Date effectiveDate, std::vector<double> rates) {
+    inline double fixedRateBondPriceByYieldEngine(double settlementDays, double yield, std::string cal, double faceAmount, int businessDayConvention, int compound, double redemption, int dayCounter, int frequency, QuantLib::Date maturityDate, QuantLib::Date issueDate, QuantLib::Date effectiveDate, std::vector<double> rates) {
         typedef SEXP(*Ptr_fixedRateBondPriceByYieldEngine)(SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP,SEXP);
         static Ptr_fixedRateBondPriceByYieldEngine p_fixedRateBondPriceByYieldEngine = NULL;
         if (p_fixedRateBondPriceByYieldEngine == NULL) {
-            validateSignature("double(*fixedRateBondPriceByYieldEngine)(double,double,std::string,double,double,double,double,double,double,QuantLib::Date,QuantLib::Date,QuantLib::Date,std::vector<double>)");
+            validateSignature("double(*fixedRateBondPriceByYieldEngine)(double,double,std::string,double,int,int,double,int,int,QuantLib::Date,QuantLib::Date,QuantLib::Date,std::vector<double>)");
             p_fixedRateBondPriceByYieldEngine = (Ptr_fixedRateBondPriceByYieldEngine)R_GetCCallable("RQuantLib", "RQuantLib_fixedRateBondPriceByYieldEngine");
         }
         RObject __result;

--- a/inst/include/rquantlib_internal.h
+++ b/inst/include/rquantlib_internal.h
@@ -160,12 +160,12 @@ int dateFromR(const Rcpp::Date &d); // using 'new' API's Rcpp::Date
 
 //utility functions for parameters of fixed-income instrument function
 QuantLib::IborIndex getIborIndex(std::string type);
-QuantLib::Frequency getFrequency(const double n);
-QuantLib::TimeUnit getTimeUnit(const double n);
-QuantLib::Compounding getCompounding(const double n);
-QuantLib::BusinessDayConvention getBusinessDayConvention(const double n);
-QuantLib::DayCounter getDayCounter(const double n);
-QuantLib::DateGeneration::Rule getDateGenerationRule(const double n);
+QuantLib::Frequency getFrequency(const int n);
+QuantLib::TimeUnit getTimeUnit(const int n);
+QuantLib::Compounding getCompounding(const int n);
+QuantLib::BusinessDayConvention getBusinessDayConvention(const int n);
+QuantLib::DayCounter getDayCounter(const int n);
+QuantLib::DateGeneration::Rule getDateGenerationRule(const int n);
 boost::shared_ptr<QuantLib::YieldTermStructure> buildTermStructure(Rcpp::List params, Rcpp::List);
 QuantLib::Schedule getSchedule(Rcpp::List rparam);
 boost::shared_ptr<QuantLib::FixedRateBond> getFixedRateBond(Rcpp::List bondparam, std::vector<double> ratesVec, Rcpp::List scheduleparam);
@@ -193,7 +193,7 @@ Rcpp::DataFrame getCashFlowDataFrame(const QuantLib::Leg &bondCashFlow);
 // fill QL data structures based on data.frames
 QuantLib::DividendSchedule getDividendSchedule(Rcpp::DataFrame dividendScheduleFrame);
 QuantLib::CallabilitySchedule getCallabilitySchedule(Rcpp::DataFrame callabilityScheduleFrame);
-QuantLib::Duration::Type getDurationType(const double n);
+QuantLib::Duration::Type getDurationType(const int n);
 
 // dates.cpp
 QuantLib::Date advanceDate(QuantLib::Date issueDate, int days);

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -137,16 +137,16 @@ BEGIN_RCPP
 END_RCPP
 }
 // zeroPriceByYieldEngine
-double zeroPriceByYieldEngine(double yield, double faceAmount, double dayCounter, double frequency, double businessDayConvention, double compound, QuantLib::Date maturityDate, QuantLib::Date issueDate);
+double zeroPriceByYieldEngine(double yield, double faceAmount, int dayCounter, int frequency, int businessDayConvention, int compound, QuantLib::Date maturityDate, QuantLib::Date issueDate);
 static SEXP RQuantLib_zeroPriceByYieldEngine_try(SEXP yieldSEXP, SEXP faceAmountSEXP, SEXP dayCounterSEXP, SEXP frequencySEXP, SEXP businessDayConventionSEXP, SEXP compoundSEXP, SEXP maturityDateSEXP, SEXP issueDateSEXP) {
 BEGIN_RCPP
     Rcpp::RObject __result;
     Rcpp::traits::input_parameter< double >::type yield(yieldSEXP);
     Rcpp::traits::input_parameter< double >::type faceAmount(faceAmountSEXP);
-    Rcpp::traits::input_parameter< double >::type dayCounter(dayCounterSEXP);
-    Rcpp::traits::input_parameter< double >::type frequency(frequencySEXP);
-    Rcpp::traits::input_parameter< double >::type businessDayConvention(businessDayConventionSEXP);
-    Rcpp::traits::input_parameter< double >::type compound(compoundSEXP);
+    Rcpp::traits::input_parameter< int >::type dayCounter(dayCounterSEXP);
+    Rcpp::traits::input_parameter< int >::type frequency(frequencySEXP);
+    Rcpp::traits::input_parameter< int >::type businessDayConvention(businessDayConventionSEXP);
+    Rcpp::traits::input_parameter< int >::type compound(compoundSEXP);
     Rcpp::traits::input_parameter< QuantLib::Date >::type maturityDate(maturityDateSEXP);
     Rcpp::traits::input_parameter< QuantLib::Date >::type issueDate(issueDateSEXP);
     __result = Rcpp::wrap(zeroPriceByYieldEngine(yield, faceAmount, dayCounter, frequency, businessDayConvention, compound, maturityDate, issueDate));
@@ -174,16 +174,16 @@ RcppExport SEXP RQuantLib_zeroPriceByYieldEngine(SEXP yieldSEXP, SEXP faceAmount
     return __result;
 }
 // zeroYieldByPriceEngine
-double zeroYieldByPriceEngine(double price, double faceAmount, double dayCounter, double frequency, double businessDayConvention, double compound, QuantLib::Date maturityDate, QuantLib::Date issueDate);
+double zeroYieldByPriceEngine(double price, double faceAmount, int dayCounter, int frequency, int businessDayConvention, int compound, QuantLib::Date maturityDate, QuantLib::Date issueDate);
 static SEXP RQuantLib_zeroYieldByPriceEngine_try(SEXP priceSEXP, SEXP faceAmountSEXP, SEXP dayCounterSEXP, SEXP frequencySEXP, SEXP businessDayConventionSEXP, SEXP compoundSEXP, SEXP maturityDateSEXP, SEXP issueDateSEXP) {
 BEGIN_RCPP
     Rcpp::RObject __result;
     Rcpp::traits::input_parameter< double >::type price(priceSEXP);
     Rcpp::traits::input_parameter< double >::type faceAmount(faceAmountSEXP);
-    Rcpp::traits::input_parameter< double >::type dayCounter(dayCounterSEXP);
-    Rcpp::traits::input_parameter< double >::type frequency(frequencySEXP);
-    Rcpp::traits::input_parameter< double >::type businessDayConvention(businessDayConventionSEXP);
-    Rcpp::traits::input_parameter< double >::type compound(compoundSEXP);
+    Rcpp::traits::input_parameter< int >::type dayCounter(dayCounterSEXP);
+    Rcpp::traits::input_parameter< int >::type frequency(frequencySEXP);
+    Rcpp::traits::input_parameter< int >::type businessDayConvention(businessDayConventionSEXP);
+    Rcpp::traits::input_parameter< int >::type compound(compoundSEXP);
     Rcpp::traits::input_parameter< QuantLib::Date >::type maturityDate(maturityDateSEXP);
     Rcpp::traits::input_parameter< QuantLib::Date >::type issueDate(issueDateSEXP);
     __result = Rcpp::wrap(zeroYieldByPriceEngine(price, faceAmount, dayCounter, frequency, businessDayConvention, compound, maturityDate, issueDate));
@@ -211,7 +211,7 @@ RcppExport SEXP RQuantLib_zeroYieldByPriceEngine(SEXP priceSEXP, SEXP faceAmount
     return __result;
 }
 // fixedRateBondYieldByPriceEngine
-double fixedRateBondYieldByPriceEngine(double settlementDays, double price, std::string cal, double faceAmount, double businessDayConvention, double compound, double redemption, double dayCounter, double frequency, QuantLib::Date maturityDate, QuantLib::Date issueDate, QuantLib::Date effectiveDate, std::vector<double> rates);
+double fixedRateBondYieldByPriceEngine(double settlementDays, double price, std::string cal, double faceAmount, int businessDayConvention, int compound, double redemption, int dayCounter, int frequency, QuantLib::Date maturityDate, QuantLib::Date issueDate, QuantLib::Date effectiveDate, std::vector<double> rates);
 static SEXP RQuantLib_fixedRateBondYieldByPriceEngine_try(SEXP settlementDaysSEXP, SEXP priceSEXP, SEXP calSEXP, SEXP faceAmountSEXP, SEXP businessDayConventionSEXP, SEXP compoundSEXP, SEXP redemptionSEXP, SEXP dayCounterSEXP, SEXP frequencySEXP, SEXP maturityDateSEXP, SEXP issueDateSEXP, SEXP effectiveDateSEXP, SEXP ratesSEXP) {
 BEGIN_RCPP
     Rcpp::RObject __result;
@@ -219,11 +219,11 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< double >::type price(priceSEXP);
     Rcpp::traits::input_parameter< std::string >::type cal(calSEXP);
     Rcpp::traits::input_parameter< double >::type faceAmount(faceAmountSEXP);
-    Rcpp::traits::input_parameter< double >::type businessDayConvention(businessDayConventionSEXP);
-    Rcpp::traits::input_parameter< double >::type compound(compoundSEXP);
+    Rcpp::traits::input_parameter< int >::type businessDayConvention(businessDayConventionSEXP);
+    Rcpp::traits::input_parameter< int >::type compound(compoundSEXP);
     Rcpp::traits::input_parameter< double >::type redemption(redemptionSEXP);
-    Rcpp::traits::input_parameter< double >::type dayCounter(dayCounterSEXP);
-    Rcpp::traits::input_parameter< double >::type frequency(frequencySEXP);
+    Rcpp::traits::input_parameter< int >::type dayCounter(dayCounterSEXP);
+    Rcpp::traits::input_parameter< int >::type frequency(frequencySEXP);
     Rcpp::traits::input_parameter< QuantLib::Date >::type maturityDate(maturityDateSEXP);
     Rcpp::traits::input_parameter< QuantLib::Date >::type issueDate(issueDateSEXP);
     Rcpp::traits::input_parameter< QuantLib::Date >::type effectiveDate(effectiveDateSEXP);
@@ -253,7 +253,7 @@ RcppExport SEXP RQuantLib_fixedRateBondYieldByPriceEngine(SEXP settlementDaysSEX
     return __result;
 }
 // fixedRateBondPriceByYieldEngine
-double fixedRateBondPriceByYieldEngine(double settlementDays, double yield, std::string cal, double faceAmount, double businessDayConvention, double compound, double redemption, double dayCounter, double frequency, QuantLib::Date maturityDate, QuantLib::Date issueDate, QuantLib::Date effectiveDate, std::vector<double> rates);
+double fixedRateBondPriceByYieldEngine(double settlementDays, double yield, std::string cal, double faceAmount, int businessDayConvention, int compound, double redemption, int dayCounter, int frequency, QuantLib::Date maturityDate, QuantLib::Date issueDate, QuantLib::Date effectiveDate, std::vector<double> rates);
 static SEXP RQuantLib_fixedRateBondPriceByYieldEngine_try(SEXP settlementDaysSEXP, SEXP yieldSEXP, SEXP calSEXP, SEXP faceAmountSEXP, SEXP businessDayConventionSEXP, SEXP compoundSEXP, SEXP redemptionSEXP, SEXP dayCounterSEXP, SEXP frequencySEXP, SEXP maturityDateSEXP, SEXP issueDateSEXP, SEXP effectiveDateSEXP, SEXP ratesSEXP) {
 BEGIN_RCPP
     Rcpp::RObject __result;
@@ -261,11 +261,11 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< double >::type yield(yieldSEXP);
     Rcpp::traits::input_parameter< std::string >::type cal(calSEXP);
     Rcpp::traits::input_parameter< double >::type faceAmount(faceAmountSEXP);
-    Rcpp::traits::input_parameter< double >::type businessDayConvention(businessDayConventionSEXP);
-    Rcpp::traits::input_parameter< double >::type compound(compoundSEXP);
+    Rcpp::traits::input_parameter< int >::type businessDayConvention(businessDayConventionSEXP);
+    Rcpp::traits::input_parameter< int >::type compound(compoundSEXP);
     Rcpp::traits::input_parameter< double >::type redemption(redemptionSEXP);
-    Rcpp::traits::input_parameter< double >::type dayCounter(dayCounterSEXP);
-    Rcpp::traits::input_parameter< double >::type frequency(frequencySEXP);
+    Rcpp::traits::input_parameter< int >::type dayCounter(dayCounterSEXP);
+    Rcpp::traits::input_parameter< int >::type frequency(frequencySEXP);
     Rcpp::traits::input_parameter< QuantLib::Date >::type maturityDate(maturityDateSEXP);
     Rcpp::traits::input_parameter< QuantLib::Date >::type issueDate(issueDateSEXP);
     Rcpp::traits::input_parameter< QuantLib::Date >::type effectiveDate(effectiveDateSEXP);
@@ -1441,10 +1441,10 @@ END_RCPP
 static int RQuantLib_RcppExport_validate(const char* sig) { 
     static std::set<std::string> signatures;
     if (signatures.empty()) {
-        signatures.insert("double(*zeroPriceByYieldEngine)(double,double,double,double,double,double,QuantLib::Date,QuantLib::Date)");
-        signatures.insert("double(*zeroYieldByPriceEngine)(double,double,double,double,double,double,QuantLib::Date,QuantLib::Date)");
-        signatures.insert("double(*fixedRateBondYieldByPriceEngine)(double,double,std::string,double,double,double,double,double,double,QuantLib::Date,QuantLib::Date,QuantLib::Date,std::vector<double>)");
-        signatures.insert("double(*fixedRateBondPriceByYieldEngine)(double,double,std::string,double,double,double,double,double,double,QuantLib::Date,QuantLib::Date,QuantLib::Date,std::vector<double>)");
+        signatures.insert("double(*zeroPriceByYieldEngine)(double,double,int,int,int,int,QuantLib::Date,QuantLib::Date)");
+        signatures.insert("double(*zeroYieldByPriceEngine)(double,double,int,int,int,int,QuantLib::Date,QuantLib::Date)");
+        signatures.insert("double(*fixedRateBondYieldByPriceEngine)(double,double,std::string,double,int,int,double,int,int,QuantLib::Date,QuantLib::Date,QuantLib::Date,std::vector<double>)");
+        signatures.insert("double(*fixedRateBondPriceByYieldEngine)(double,double,std::string,double,int,int,double,int,int,QuantLib::Date,QuantLib::Date,QuantLib::Date,std::vector<double>)");
         signatures.insert("Rcpp::List(*FloatBond1)(Rcpp::List,std::vector<double>,std::vector<double>,std::vector<double>,std::vector<double>,Rcpp::List,Rcpp::List,Rcpp::List,Rcpp::List)");
         signatures.insert("Rcpp::List(*FloatBond2)(Rcpp::List,std::vector<double>,std::vector<double>,std::vector<double>,std::vector<double>,Rcpp::List,Rcpp::List,Rcpp::List,Rcpp::List,Rcpp::List,Rcpp::List)");
         signatures.insert("Rcpp::List(*FloatBond3)(Rcpp::List,std::vector<double>,std::vector<double>,std::vector<double>,std::vector<double>,Rcpp::List,Rcpp::List,Rcpp::List,Rcpp::List,Rcpp::List,Rcpp::List)");

--- a/src/affine.cpp
+++ b/src/affine.cpp
@@ -97,11 +97,11 @@ Rcpp::List affineWithRebuiltCurveEngine(Rcpp::List rparam,
     int numRows = swaptionMat.size(); 
 
     // Create dummy swap to get schedules.
-    QuantLib::Frequency fixedLegFrequency = getFrequency(Rcpp::as<double>(legparams["fixFreq"]));
+    QuantLib::Frequency fixedLegFrequency = getFrequency(Rcpp::as<int>(legparams["fixFreq"]));
     QuantLib::BusinessDayConvention fixedLegConvention = QuantLib::Unadjusted;
     QuantLib::BusinessDayConvention floatingLegConvention = QuantLib::ModifiedFollowing;
-    double fixDayCount = Rcpp::as<double>(legparams["dayCounter"]);
-    QuantLib::DayCounter swFixedLegDayCounter = getDayCounter(Rcpp::as<double>(legparams["dayCounter"]));
+    int fixDayCount = Rcpp::as<int>(legparams["dayCounter"]);
+    QuantLib::DayCounter swFixedLegDayCounter = getDayCounter(Rcpp::as<int>(legparams["dayCounter"]));
     boost::shared_ptr<QuantLib::IborIndex> swFloatingLegIndex(new QuantLib::Euribor(QuantLib::Period(Rcpp::as<int>(legparams["floatFreq"]),QuantLib::Months),rhTermStructure));
 
 

--- a/src/bonds.cpp
+++ b/src/bonds.cpp
@@ -29,10 +29,10 @@
 // [[Rcpp::export]]
 double zeroPriceByYieldEngine(double yield,
                               double faceAmount,
-                              double dayCounter,
-                              double frequency,
-                              double businessDayConvention,
-                              double compound,
+                              int dayCounter,
+                              int frequency,
+                              int businessDayConvention,
+                              int compound,
                               QuantLib::Date maturityDate,
                               QuantLib::Date issueDate) {
 
@@ -60,10 +60,10 @@ double zeroPriceByYieldEngine(double yield,
 // [[Rcpp::export]]
 double zeroYieldByPriceEngine(double price,
                               double faceAmount,
-                              double dayCounter,
-                              double frequency,
-                              double businessDayConvention,
-                              double compound,
+                              int dayCounter,
+                              int frequency,
+                              int businessDayConvention,
+                              int compound,
                               QuantLib::Date maturityDate,
                               QuantLib::Date issueDate) {
 
@@ -94,11 +94,11 @@ double fixedRateBondYieldByPriceEngine(double settlementDays,
                                        double price,
                                        std::string cal,
                                        double faceAmount,
-                                       double businessDayConvention,
-                                       double compound,
+                                       int businessDayConvention,
+                                       int compound,
                                        double redemption,
-                                       double dayCounter,
-                                       double frequency, 
+                                       int dayCounter,
+                                       int frequency,
                                        QuantLib::Date maturityDate,
                                        QuantLib::Date issueDate,
                                        QuantLib::Date effectiveDate,
@@ -131,11 +131,11 @@ double fixedRateBondPriceByYieldEngine(double settlementDays,
                                        double yield,
                                        std::string cal,
                                        double faceAmount,
-                                       double businessDayConvention,
-                                       double compound,
+                                       int businessDayConvention,
+                                       int compound,
                                        double redemption,
-                                       double dayCounter,
-                                       double frequency, 
+                                       int dayCounter,
+                                       int frequency,
                                        QuantLib::Date maturityDate,
                                        QuantLib::Date issueDate,
                                        QuantLib::Date effectiveDate,
@@ -182,15 +182,15 @@ Rcpp::List FloatingBond(Rcpp::List rparam,
     QuantLib::Date effectiveDate(Rcpp::as<QuantLib::Date>(rparam["effectiveDate"]));
     double redemption = Rcpp::as<double>(rparam["redemption"]);
 
-    double settlementDays = Rcpp::as<double>(datemisc["settlementDays"]);
+    int settlementDays = Rcpp::as<int>(datemisc["settlementDays"]);
     std::string cal = Rcpp::as<std::string>(datemisc["calendar"]);
-    double dayCounter = Rcpp::as<double>(datemisc["dayCounter"]);
-    double frequency = Rcpp::as<double>(datemisc["period"]);
-    double businessDayConvention = Rcpp::as<double>(datemisc["businessDayConvention"]);
-    double terminationDateConvention = Rcpp::as<double>(datemisc["terminationDateConvention"]);
-    double dateGeneration = Rcpp::as<double>(datemisc["dateGeneration"]);
-    double endOfMonthRule = Rcpp::as<double>(datemisc["endOfMonth"]);
-    double fixingDays = Rcpp::as<double>(datemisc["fixingDays"]);
+    int dayCounter = Rcpp::as<int>(datemisc["dayCounter"]);
+    int frequency = Rcpp::as<int>(datemisc["period"]);
+    int businessDayConvention = Rcpp::as<int>(datemisc["businessDayConvention"]);
+    int terminationDateConvention = Rcpp::as<int>(datemisc["terminationDateConvention"]);
+    int dateGeneration = Rcpp::as<int>(datemisc["dateGeneration"]);
+    int endOfMonthRule = Rcpp::as<int>(datemisc["endOfMonth"]);
+    int fixingDays = Rcpp::as<int>(datemisc["fixingDays"]);
 
     //build schedule
     QuantLib::BusinessDayConvention bdc = getBusinessDayConvention(businessDayConvention);
@@ -337,16 +337,16 @@ Rcpp::List FixedRateWithYield(Rcpp::List bondparam,
 
     // get calc parameters
     QuantLib::DayCounter calcDayCounter =
-        getDayCounter(Rcpp::as<double>(calcparam["dayCounter"]));
+        getDayCounter(Rcpp::as<int>(calcparam["dayCounter"]));
     QuantLib::Compounding compounding =
-        getCompounding(Rcpp::as<double>(calcparam["compounding"]));
+        getCompounding(Rcpp::as<int>(calcparam["compounding"]));
     QuantLib::Frequency calcFreq =
-        getFrequency(Rcpp::as<double>(calcparam["freq"]));
+        getFrequency(Rcpp::as<int>(calcparam["freq"]));
     QuantLib::Duration::Type durationType =
-        getDurationType(Rcpp::as<double>(calcparam["durationType"]));
+        getDurationType(Rcpp::as<int>(calcparam["durationType"]));
 
     boost::shared_ptr<QuantLib::FixedRateBond> bond = getFixedRateBond(bondparam, ratesVec, scheduleparam);
-    
+
     QuantLib::Date sd = bond->settlementDate();
     const Rcpp::Date settlementDate(sd.month(), sd.dayOfMonth(), sd.year());
 
@@ -368,18 +368,18 @@ Rcpp::List FixedRateWithPrice(Rcpp::List bondparam,
 
     // get calc parameters
     QuantLib::DayCounter calcDayCounter =
-        getDayCounter(Rcpp::as<double>(calcparam["dayCounter"]));
+        getDayCounter(Rcpp::as<int>(calcparam["dayCounter"]));
     QuantLib::Compounding compounding =
-        getCompounding(Rcpp::as<double>(calcparam["compounding"]));
+        getCompounding(Rcpp::as<int>(calcparam["compounding"]));
     QuantLib::Frequency calcFreq =
-        getFrequency(Rcpp::as<double>(calcparam["freq"]));
+        getFrequency(Rcpp::as<int>(calcparam["freq"]));
     QuantLib::Duration::Type durationType =
-        getDurationType(Rcpp::as<double>(calcparam["durationType"]));
+        getDurationType(Rcpp::as<int>(calcparam["durationType"]));
     double accuracy = Rcpp::as<double>(calcparam["accuracy"]);
     double maxEvaluations = Rcpp::as<double>(calcparam["maxEvaluations"]);
 
     boost::shared_ptr<QuantLib::FixedRateBond> bond = getFixedRateBond(bondparam, ratesVec, scheduleparam);
-    
+
     QuantLib::Date sd = bond->settlementDate();
     const Rcpp::Date settlementDate(sd.month(), sd.dayOfMonth(), sd.year());
     const double accrued = bond->accruedAmount();
@@ -405,13 +405,13 @@ Rcpp::List FixedRateWithRebuiltCurve(Rcpp::List bondparam,
     
     // get calc parameters
     QuantLib::DayCounter calcDayCounter =
-        getDayCounter(Rcpp::as<double>(calcparam["dayCounter"]));
+        getDayCounter(Rcpp::as<int>(calcparam["dayCounter"]));
     QuantLib::Compounding compounding =
-        getCompounding(Rcpp::as<double>(calcparam["compounding"]));
+        getCompounding(Rcpp::as<int>(calcparam["compounding"]));
     QuantLib::Frequency calcFreq =
-        getFrequency(Rcpp::as<double>(calcparam["freq"]));
+        getFrequency(Rcpp::as<int>(calcparam["freq"]));
     QuantLib::Duration::Type durationType =
-        getDurationType(Rcpp::as<double>(calcparam["durationType"]));
+        getDurationType(Rcpp::as<int>(calcparam["durationType"]));
     double accuracy = Rcpp::as<double>(calcparam["accuracy"]);
     double maxEvaluations = Rcpp::as<double>(calcparam["maxEvaluations"]);
     

--- a/src/discount.cpp
+++ b/src/discount.cpp
@@ -54,14 +54,13 @@ Rcpp::List discountCurveEngine(Rcpp::List rparams,
     }
     // initialise from the singleton instance
     QuantLib::Calendar calendar = RQLContext::instance().calendar;
-    //Integer fixingDays = RQLContext::instance().fixingDays;
-    
+
     // Any DayCounter would be fine.
     // ActualActual::ISDA ensures that 30 years is 30.0
     QuantLib::DayCounter termStructureDayCounter = QuantLib::ActualActual(QuantLib::ActualActual::ISDA);
     double tolerance = 1.0e-8;
     boost::shared_ptr<QuantLib::YieldTermStructure> curve;
-    
+
     if (firstQuoteName.compare("flat") == 0) {            // Create a flat term structure.
         double rateQuote = Rcpp::as<double>(tslist[0]);
         //boost::shared_ptr<Quote> flatRate(new SimpleQuote(rateQuote));
@@ -75,24 +74,23 @@ Rcpp::List discountCurveEngine(Rcpp::List rparams,
         std::vector<boost::shared_ptr<QuantLib::RateHelper> > curveInput;
 
         // For general swap inputs, not elegant but necessary to pass to getRateHelper()
-        double fixDayCount = Rcpp::as<double>(legParams["dayCounter"]);
-        double fixFreq   = Rcpp::as<double>(legParams["fixFreq"]) ;
-        int floatFreq = Rcpp::as<int>(legParams["floatFreq"]); 
-        //int floatFreq2 = 6;
-        
+        int fixDayCount = Rcpp::as<int>(legParams["dayCounter"]);
+        int fixFreq   = Rcpp::as<int>(legParams["fixFreq"]) ;
+        int floatFreq = Rcpp::as<int>(legParams["floatFreq"]);
+
         for(i = 0; i < tslist.size(); i++) {
             std::string name = tsNames[i];
             double val = Rcpp::as<double>(tslist[i]);
             boost::shared_ptr<QuantLib::RateHelper> rh =
-                ObservableDB::instance().getRateHelper(name, val, fixDayCount,fixFreq, floatFreq);
+                ObservableDB::instance().getRateHelper(name, val, fixDayCount, fixFreq, floatFreq);
             // edd 2009-11-01 FIXME NULL_RateHelper no longer builds under 0.9.9
             // if (rh == NULL_RateHelper)
             if (rh.get() == NULL)
                 throw std::range_error("Unknown rate in getRateHelper");
             curveInput.push_back(rh);
         }
-        boost::shared_ptr<QuantLib::YieldTermStructure> 
-            ts = getTermStructure(interpWhat, interpHow, settlementDate, 
+        boost::shared_ptr<QuantLib::YieldTermStructure>
+            ts = getTermStructure(interpWhat, interpHow, settlementDate,
                                   curveInput, termStructureDayCounter, tolerance);
         curve = ts;
     }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -179,20 +179,20 @@ QuantLib::Schedule getSchedule(Rcpp::List rparam) {
         calendar = *p;
     }
     QuantLib::BusinessDayConvention businessDayConvention =
-        getBusinessDayConvention(Rcpp::as<double>(rparam["businessDayConvention"]));
+        getBusinessDayConvention(Rcpp::as<int>(rparam["businessDayConvention"]));
     QuantLib::BusinessDayConvention terminationDateConvention =
-        getBusinessDayConvention(Rcpp::as<double>(rparam["terminationDateConvention"]));
+        getBusinessDayConvention(Rcpp::as<int>(rparam["terminationDateConvention"]));
     // keep these default values for the last two parameters for backward compatibility
     // (although in QuantLib::schedule they have no default values)
     QuantLib::DateGeneration::Rule dateGeneration = QuantLib::DateGeneration::Backward;
     if(rparam.containsElementNamed("dateGeneration") ) {
-        dateGeneration = getDateGenerationRule(Rcpp::as<double>(rparam["dateGeneration"]));
+        dateGeneration = getDateGenerationRule(Rcpp::as<int>(rparam["dateGeneration"]));
     }
     bool endOfMonth = false;
     if(rparam.containsElementNamed("endOfMonth") ) {
         endOfMonth = (Rcpp::as<double>(rparam["endOfMonth"]) == 1) ? true : false;
     }
-    
+
     QuantLib::Schedule schedule(effectiveDate,
                                 maturityDate,
                                 period,
@@ -214,7 +214,7 @@ boost::shared_ptr<QuantLib::FixedRateBond> getFixedRateBond(
         getDayCounter(Rcpp::as<double>(bondparam["dayCounter"]));
     QuantLib::BusinessDayConvention paymentConvention = QuantLib::Following;
     if(bondparam.containsElementNamed("paymentConvention") ) {
-        paymentConvention = getBusinessDayConvention(Rcpp::as<double>(bondparam["paymentConvention"]));
+        paymentConvention = getBusinessDayConvention(Rcpp::as<int>(bondparam["paymentConvention"]));
     }
     double redemption = 100.0;
     if(bondparam.containsElementNamed("redemption") ) {
@@ -240,13 +240,13 @@ boost::shared_ptr<QuantLib::FixedRateBond> getFixedRateBond(
     }
     QuantLib::BusinessDayConvention exCouponConvention = QuantLib::Unadjusted;
     if(bondparam.containsElementNamed("exCouponConvention") ) {
-        exCouponConvention = getBusinessDayConvention(Rcpp::as<double>(bondparam["exCouponConvention"]));
+        exCouponConvention = getBusinessDayConvention(Rcpp::as<int>(bondparam["exCouponConvention"]));
     }
     bool exCouponEndOfMonth = false;
     if(bondparam.containsElementNamed("exCouponEndOfMonth") ) {
         exCouponEndOfMonth = (Rcpp::as<double>(bondparam["exCouponEndOfMonth"]) == 1) ? true : false;
     }
-    
+
     QuantLib::Schedule schedule = getSchedule(scheduleparam);
     boost::shared_ptr<QuantLib::FixedRateBond> result(
         new QuantLib::FixedRateBond(settlementDays,
@@ -364,7 +364,7 @@ makeProcess(const boost::shared_ptr<QuantLib::Quote>& u,
 //     return(d.getDate() + QLtoJan1970Offset);
 // }
 
-QuantLib::DayCounter getDayCounter(const double n){
+QuantLib::DayCounter getDayCounter(const int n){
     if (n==0)
         return QuantLib::Actual360();
     else if (n==1)
@@ -395,107 +395,35 @@ QuantLib::DayCounter getDayCounter(const double n){
         return QuantLib::ActualActual(QuantLib::ActualActual::Euro);
 }
 
-QuantLib::BusinessDayConvention getBusinessDayConvention(const double n){
-    if (n==0) 
-        return QuantLib::Following;
-    else if (n==1) 
-        return QuantLib::ModifiedFollowing;
-    else if (n==2) 
-        return QuantLib::Preceding;
-    else if (n==3) 
-        return QuantLib::ModifiedPreceding;
-    else if (n==4)
-        return QuantLib::Unadjusted;
-    else if (n==5)
-        return QuantLib::HalfMonthModifiedFollowing;
-    else if (n==6)
-        return QuantLib::Nearest;
-    else  
-        return QuantLib::Unadjusted;
+QuantLib::BusinessDayConvention getBusinessDayConvention(const int n){
+    return static_cast<QuantLib::BusinessDayConvention>(n);
 }
 
-QuantLib::Compounding getCompounding(const double n){
-    if (n==0) 
-        return QuantLib::Simple;
-    else if (n==1) 
-        return QuantLib::Compounded;
-    else if (n==2) 
-        return QuantLib::Continuous;
-    else 
-        return QuantLib::SimpleThenCompounded;
+QuantLib::Compounding getCompounding(const int n){
+    return static_cast<QuantLib::Compounding>(n);
 }
 
-QuantLib::Frequency getFrequency(const double n){
-
-    if (n==-1) 
-        return QuantLib::NoFrequency;
-    else if (n==0) 
-        return QuantLib::Once;
-    else if (n==1) 
-        return QuantLib::Annual;
-    else if (n==2) 
-        return QuantLib::Semiannual;
-    else if (n==3) 
-        return QuantLib::EveryFourthMonth;
-    else if (n==4) 
-        return QuantLib::Quarterly;
-    else if (n==6) 
-        return QuantLib::Bimonthly;
-    else if (n==12) 
-        return QuantLib::Monthly;
-    else if (n==13) 
-        return QuantLib::EveryFourthWeek;
-    else if (n==26) 
-        return QuantLib::Biweekly;
-    else if (n==52) 
-        return QuantLib::Weekly;
-    else if (n==365) 
-        return QuantLib::Daily;
-    else 
-        return QuantLib::OtherFrequency;   
+QuantLib::Frequency getFrequency(const int n){
+    return static_cast<QuantLib::Frequency>(n);
 }
 
 QuantLib::Period periodByTimeUnit(int length, std::string unit){
     QuantLib::TimeUnit tu = QuantLib::Years;
-    if (unit=="Days") 
+    if (unit=="Days")
         tu = QuantLib::Days;
-    if (unit=="Weeks") 
+    if (unit=="Weeks")
         tu = QuantLib::Weeks;
-    if (unit=="Months") 
+    if (unit=="Months")
         tu = QuantLib::Months;
     return QuantLib::Period(length, tu);
 }
 
-QuantLib::TimeUnit getTimeUnit(const double n){
-    if (n==0) 
-        return QuantLib::Days;
-    else if (n==1) 
-        return QuantLib::Weeks;
-    else if (n==2) 
-        return QuantLib::Months;
-    else 
-        return QuantLib::Years;
+QuantLib::TimeUnit getTimeUnit(const int n){
+    return static_cast<QuantLib::TimeUnit>(n);
 }
 
-QuantLib::DateGeneration::Rule getDateGenerationRule(const double n){
-    if (n==0) 
-        return QuantLib::DateGeneration::Backward;
-    else if (n==1) 
-        return QuantLib::DateGeneration::Forward;
-    else if (n==2) 
-        return QuantLib::DateGeneration::Zero;
-    else if (n==3) 
-        return QuantLib::DateGeneration::ThirdWednesday;
-    else if (n==4) 
-        return QuantLib::DateGeneration::Twentieth;
-    else if (n==5)
-        return QuantLib::DateGeneration::TwentiethIMM;
-    else if (n==6)
-        return QuantLib::DateGeneration::OldCDS;
-    else if (n==7)
-        return QuantLib::DateGeneration::CDS;
-    else 
-        return QuantLib::DateGeneration::TwentiethIMM;
+QuantLib::DateGeneration::Rule getDateGenerationRule(const int n){
+    return static_cast<QuantLib::DateGeneration::Rule>(n);
 }
 
 boost::shared_ptr<QuantLib::IborIndex> buildIborIndex(std::string type,
@@ -610,16 +538,8 @@ QuantLib::CallabilitySchedule getCallabilitySchedule(Rcpp::DataFrame callScheDF)
     return callabilitySchedule;
 }
 
-QuantLib::Duration::Type getDurationType(const double n) {
-    if (n==0) 
-        return QuantLib::Duration::Simple;
-    else if (n==1) 
-        return QuantLib::Duration::Macaulay;
-    else if (n==2) 
-        return QuantLib::Duration::Modified;
-    else {
-        throw std::range_error("Invalid duration type " + boost::lexical_cast<std::string>(n));
-    }
+QuantLib::Duration::Type getDurationType(const int n) {
+    return static_cast<QuantLib::Duration::Type>(n);
 }
 
 //' This function returns the QuantLib version string as encoded in the header


### PR DESCRIPTION
I think it makes more sense to have all these enums as ``int`` instead of ``double``. I also use a static_cast instead of a giant switch. It's simpler, and also more futureproof in case QuantLib adds more cases to these.

I've also updated the Rcpp generated files. Some of the changes reflect changes to the functions that @tleitch did recently. I can try to disentangle his commits from mine if it's an issue.