### PR TITLE
More flexible swap construction

### DIFF
--- a/src/curves.cpp
+++ b/src/curves.cpp
@@ -93,9 +93,17 @@ ObservableDB::getRateHelper(std::string& ticker, QuantLib::Rate r, double fixDay
         return depo;
     } else if (type == RQLSwap) {
         QuantLib::Frequency swFixedLegFrequency = getFrequency(fixFreq);
-        QuantLib::BusinessDayConvention swFixedLegConvention = QuantLib::Unadjusted;
+        QuantLib::BusinessDayConvention swFixedLegConvention = QuantLib::ModifiedFollowing;
         QuantLib::DayCounter swFixedLegDayCounter = getDayCounter(fixDayCount);
-        boost::shared_ptr<QuantLib::IborIndex> swFloatingLegIndex(new QuantLib::Euribor(QuantLib::Period(floatFreq,QuantLib::Months)));
+        boost::shared_ptr<QuantLib::IborIndex>
+            swFloatingLegIndex(new QuantLib::IborIndex("WOIbor", floatFreq * QuantLib::Months,
+                                                       fixingDays, // settlement days
+                                                       QuantLib::EURCurrency(),
+                                                       calendar,
+                                                       QuantLib::ModifiedFollowing,
+                                                       true,
+                                                       QuantLib::Actual360(),
+                                                       QuantLib::Handle<QuantLib::YieldTermStructure>()));
         boost::shared_ptr<QuantLib::Quote> quote(new QuantLib::SimpleQuote(r));
         boost::shared_ptr<QuantLib::RateHelper> 
             swap(new QuantLib::SwapRateHelper(QuantLib::Handle<QuantLib::Quote>(quote),


### PR DESCRIPTION
This PR is short and self-contained, I hope it will have an easier time.
Right now, by forcing to use euribor in the construction of the swap instruments, the curve will fail to build for certain dates if I use a US calendar (for instance may 1st is a holiday according to TARGET, but not in the US). With this PR, the floating index will use the calendar from the RQLContext singleton.

If you check the quantlib code here: https://github.com/lballabio/QuantLib/blob/master/ql/indexes/ibor/euribor.cpp#L59, by using a TARGET calendar and fixingDays=2 (which is the default), this is exactly equivalent to using an Euribor index.