### PR TITLE
Windows: update to libquantlib 1.16

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -4,13 +4,18 @@
 # Copyright 2005         Uwe Ligges
 # Copyright 2008 - 2018  Dirk Eddelbuettel
 # Copyright 2011         Uwe Ligges, Brian Ripley, and Josh Ulrich
-# Copyright 2018         Jeroen Ooms
+# Copyright 2018 - 2019  Jeroen Ooms
 
-RWINLIB=../windows/quantlib-1.14
+RWINLIB=../windows/quantlib-1.16
 PKG_CPPFLAGS=-I$(RWINLIB)/include -I../inst/include
 PKG_CXXFLAGS=$(SHLIB_OPENMP_CXXFLAGS) -DBOOST_NO_AUTO_PTR -Wno-deprecated-declarations
 ## NB directory layout with arch/lib is quantlib upstream default which is followed here
-PKG_LIBS=-L$(RWINLIB)/${R_ARCH}/lib -lQuantLib $(SHLIB_OPENMP_CXXFLAGS)
+
+TARGET = $(subst gcc,lib,$(COMPILED_BY))
+PKG_LIBS = \
+	-L$(RWINLIB)/$(TARGET)$(R_ARCH)/lib \
+	-L$(RWINLIB)/lib$(R_ARCH)/lib \
+	-lQuantLib $(SHLIB_OPENMP_CXXFLAGS)
 
 # Use C++11 for long long in Boost headers
 CXX_STD=CXX11

--- a/tools/winlibs.R
+++ b/tools/winlibs.R
@@ -1,9 +1,16 @@
 # Build against mingw-w64 build of quantlib
-if (!file.exists("../windows/quantlib-1.14/include/ql/quantlib.hpp")) {
+if (!file.exists("../windows/quantlib-1.16/include/ql/quantlib.hpp")) {
   if (getRversion() < "3.3.0") setInternet2()
-  download.file("https://github.com/rwinlib/quantlib/archive/v1.14.zip", "lib.zip", quiet = TRUE)
+  download.file("https://github.com/rwinlib/quantlib/archive/v1.16.zip", "quantlib-1.16.zip", quiet = TRUE)
   dir.create("../windows", showWarnings = FALSE)
-  unzip("lib.zip", exdir = "../windows")
-  unzip("../windows/quantlib-1.14/lib.zip", exdir = "../windows/quantlib-1.14")
-  unlink("lib.zip")
+  unzip("quantlib-1.16.zip", exdir = "../windows")
+  unlink("quantlib-1.16.zip")
+  
+  # Static libraries for the told toolchain
+  unzip("../windows/quantlib-1.16/lib-4.9.3.zip", exdir = "../windows/quantlib-1.16")
+  
+  # Static libraries for the new toolchain
+  if (getRversion() > "3.6.99"){
+    unzip("../windows/quantlib-1.16/lib.zip", exdir = "../windows/quantlib-1.16")
+  }
 }


### PR DESCRIPTION
This took an unholy amount of time so I hope you appreciate it.  Updates quantlib on Windows to the latest 1.16 and adds support the forthcoming GCC 8+ toolchain.

Output from winbuilder: 

 - https://win-builder.r-project.org/7EPd7OQI6oBS/
 - https://win-builder.r-project.org/g4w61c4hMDnu

If you can submit this before CRAN closes shop for the toolchain migration, that would be fantastic.