### PR TITLE
Add additional Thirty360 day counters

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2021-12-03  Dirk Eddelbuettel  <edd@debian.org>
+
+	* src/utils.cpp (getDayCounter): Use Rcpp::stop on error
+
+2021-11-30  Kai Lin  <klin441@gmail.com>
+
+	* src/utils.cpp (getDayCounter): Additional day counters
+
 2021-11-29  Dirk Eddelbuettel  <edd@debian.org>
 
 	* src/utils.cpp (getDayCounter): Correct Thirty360() use

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -406,9 +406,9 @@ QuantLib::DayCounter getDayCounter(const double n){
     else if (n==19)
         return QuantLib::Thirty360(QuantLib::Thirty360::German);
     else
-        // Stop on verbose error.
-        // Do not silently default to the arbitrarily last else statement because it can conceal bugs in user code.
-        throw std::range_error("Unknown option " + std::to_string(n)); // is this the right way to cast double to string?
+        // Stop on verbose error -- Do not silently default to the arbitrarily
+        // last else statement because it can conceal bugs in user code.
+        Rcpp::stop("Unknown option '%d'", n);
 }
 
 QuantLib::BusinessDayConvention getBusinessDayConvention(const double n){

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -367,10 +367,8 @@ QuantLib::DayCounter getDayCounter(const double n){
         return QuantLib::Actual360();
     else if (n==1)
         return QuantLib::Actual365Fixed();
-#ifdef RQUANTLIB_USE_ACTUALACTUAL
     else if (n==2)
-        return QuantLib::ActualActual();
-#endif
+        return QuantLib::ActualActual(QuantLib::ActualActual::ISDA); // reasonable default for back compatibility
     else if (n==3)
         return QuantLib::Business252();
     else if (n==4)
@@ -378,7 +376,7 @@ QuantLib::DayCounter getDayCounter(const double n){
     else if (n==5)
         return QuantLib::SimpleDayCounter();
     else if (n==6)
-        return QuantLib::Thirty360(QuantLib::Thirty360::BondBasis);
+        return QuantLib::Thirty360(QuantLib::Thirty360::BondBasis);  // reasonable default for back compatibility
 #ifdef RQUANTLIB_USE_ACTUAL365NOLEAP
      else if (n==7)
          return QuantLib::Actual365NoLeap();
@@ -393,8 +391,24 @@ QuantLib::DayCounter getDayCounter(const double n){
         return QuantLib::ActualActual(QuantLib::ActualActual::Historical);
     else if (n==12)
         return QuantLib::ActualActual(QuantLib::ActualActual::AFB);
-    else // if (n==13)
+    else if (n==13)
         return QuantLib::ActualActual(QuantLib::ActualActual::Euro);
+    else if (n==14)
+        return QuantLib::Thirty360(QuantLib::Thirty360::USA);
+    else if (n==15)
+        return QuantLib::Thirty360(QuantLib::Thirty360::BondBasis);
+    else if (n==16)
+        return QuantLib::Thirty360(QuantLib::Thirty360::European);
+    else if (n==17)
+        return QuantLib::Thirty360(QuantLib::Thirty360::EurobondBasis);
+    else if (n==18)
+        return QuantLib::Thirty360(QuantLib::Thirty360::Italian);
+    else if (n==19)
+        return QuantLib::Thirty360(QuantLib::Thirty360::German);
+    else
+        // Stop on verbose error.
+        // Do not silently default to the arbitrarily last else statement because it can conceal bugs in user code.
+        throw std::range_error("Unknown option " + std::to_string(n)); // is this the right way to cast double to string?
 }
 
 QuantLib::BusinessDayConvention getBusinessDayConvention(const double n){


### PR DESCRIPTION
Fixes #164 

Add additional Thirty360 day counters for the available conventions. Add throw error if user asked for an unknown or hard-deprecated day counter. Allow soft-deprecated day counters to be used with reasonable default conventions, for back compatibility purposes.