### PR TITLE
change deprecated Actual365NoLeap() to Actual365Fixed(Actual365Fixed::NoLeap)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2022-03-15  Kai Lin  <klin441@gmail.com>
+
+	* src/utils.cpp (getDayCounter):  change deprecated Actual365NoLeap() 
+	to Actual365Fixed(Actual365Fixed::NoLeap)
+	* man/Enum.Rd: associated documentation change
+	* man/BondUtilities.Rd: remove mentions of daycounter deprecation, 
+	remove mentions of compiler directives RQUANTLIB_USE_ACTUAL365NOLEAP 
+	and RQUANTLIB_USE_ACTUALACTUAL
+	
 2021-11-30  Kai Lin  <klin441@gmail.com>
 
 	* man/Enum.Rd: Update and extend documentation for DayCounter

--- a/man/BondUtilities.Rd
+++ b/man/BondUtilities.Rd
@@ -44,15 +44,6 @@ matchParams(params)
 }
 \details{
   The QuantLib documentation should be consulted for details.
-
-  Note that \code{Actual365NoLeap} is deprecated as of QuantLib 1.11 and
-  no longer supported by default. It can be reinstated by defining
-  \code{RQUANTLIB_USE_ACTUAL365NOLEAP}.
-
-  Also note that \code{ActualActual} is deprecated as of QuantLib 1.23
-  and no longer supported by default. It can be reinstated by
-  defining \code{RQUANTLIB_USE_ACTUALACTUAL}.
-
 }
 \references{\url{https://www.quantlib.org/} for details on \code{QuantLib}.}
 \author{Khanh Nguyen \email{knguyen@cs.umb.edu} for the \R interface;

--- a/man/BondUtilities.Rd
+++ b/man/BondUtilities.Rd
@@ -44,6 +44,18 @@ matchParams(params)
 }
 \details{
   The QuantLib documentation should be consulted for details.
+
+  Note that \code{Actual365NoLeap} is soft deprecated as of QuantLib 1.11 and hard deprecated as of
+  QuantLib 1.16. For users on QuantLib 1.16 or later, use of the RQuantLib daycounter enum with a
+  value of severn will result in \code{Actual365Fixed(Actual365Fixed::NoLeap)} which is functionally
+  equivalent to \code{Actual365NoLeap}. Previously RQuantLib allowed users to retain
+  \code{Actual365NoLeap} via defining \code{RQUANTLIB_USE_ACTUAL365NOLEAP}, but this is no longer
+  required.
+
+  Also note that \code{ActualActual} without explicit convention specification is hard deprecated
+  as of QuantLib 1.23. This is only soft-deprecated in RQuantLib by explicitly passing in the same
+  default convention. Previously RQuantLib allowed users to define
+  \code{RQUANTLIB_USE_ACTUALACTUAL}, but this is no longer required.
 }
 \references{\url{https://www.quantlib.org/} for details on \code{QuantLib}.}
 \author{Khanh Nguyen \email{knguyen@cs.umb.edu} for the \R interface;

--- a/man/Enum.Rd
+++ b/man/Enum.Rd
@@ -15,7 +15,7 @@ Reference for parameters when constructing a bond
          \code{4} \tab OneDayCounter \cr
          \code{5} \tab SimpleDayCounter \cr
          \code{6} \tab Thirty360 (NB: soft deprecated, defaults to Thirty360.BondBasis) \cr
-         \code{7} \tab Actual365NoLeap (NB: deprecated) \cr
+         \code{7} \tab Actual365Fixed.NoLeap \cr
          \code{8} \tab ActualActual.ISMA \cr
          \code{9} \tab ActualActual.Bond \cr
          \code{10} \tab ActualActual.ISDA \cr

--- a/man/Enum.Rd
+++ b/man/Enum.Rd
@@ -15,7 +15,7 @@ Reference for parameters when constructing a bond
          \code{4} \tab OneDayCounter \cr
          \code{5} \tab SimpleDayCounter \cr
          \code{6} \tab Thirty360 (NB: soft deprecated, defaults to Thirty360.BondBasis) \cr
-         \code{7} \tab Actual365Fixed.NoLeap \cr
+         \code{7} \tab Actual365Fixed.NoLeap (NB: Actual365NoLeap if QuantLib version < 1.16) \cr
          \code{8} \tab ActualActual.ISMA \cr
          \code{9} \tab ActualActual.Bond \cr
          \code{10} \tab ActualActual.ISDA \cr

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -377,10 +377,8 @@ QuantLib::DayCounter getDayCounter(const double n){
         return QuantLib::SimpleDayCounter();
     else if (n==6)
         return QuantLib::Thirty360(QuantLib::Thirty360::BondBasis);  // reasonable default for back compatibility
-#ifdef RQUANTLIB_USE_ACTUAL365NOLEAP
-     else if (n==7)
-         return QuantLib::Actual365NoLeap();
-#endif
+    else if (n==7)
+         return QuantLib::Actual365Fixed(QuantLib::Actual365Fixed::NoLeap);
     else if (n==8)
         return QuantLib::ActualActual(QuantLib::ActualActual::ISMA);
     else if (n==9)

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -378,7 +378,7 @@ QuantLib::DayCounter getDayCounter(const double n){
     else if (n==6)
         return QuantLib::Thirty360(QuantLib::Thirty360::BondBasis);  // reasonable default for back compatibility
     else if (n==7)
-#if QL_HEX_VERSION >= 0x011600f0
+#if QL_HEX_VERSION >= 0x011600f0 && !defined(RQUANTLIB_USE_ACTUAL365NOLEAP)
         return QuantLib::Actual365Fixed(QuantLib::Actual365Fixed::NoLeap);
 #else
         return QuantLib::Actual365NoLeap();

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -378,7 +378,11 @@ QuantLib::DayCounter getDayCounter(const double n){
     else if (n==6)
         return QuantLib::Thirty360(QuantLib::Thirty360::BondBasis);  // reasonable default for back compatibility
     else if (n==7)
-         return QuantLib::Actual365Fixed(QuantLib::Actual365Fixed::NoLeap);
+#if QL_HEX_VERSION >= 0x011600f0
+        return QuantLib::Actual365Fixed(QuantLib::Actual365Fixed::NoLeap);
+#else
+        return QuantLib::Actual365NoLeap();
+#endif
     else if (n==8)
         return QuantLib::ActualActual(QuantLib::ActualActual::ISMA);
     else if (n==9)


### PR DESCRIPTION
QuantLib documentation https://rkapl123.github.io/QLAnnotatedSource/d8/dbb/class_quant_lib_1_1_actual365_fixed.html

tested with 
```r
d1 <- as.Date('2020-01-01')
d2 <- as.Date('2020-07-01')
testthat::expect_equal(yearFraction(d1, d2, 7), (as.numeric(d2 - d1) - 1)/365)
```
