### PR TITLE
Change rgl.* calls to *3d calls.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2023-01-06  Duncan Murdoch     <murdoch.duncan@gmail.com>
+
+        * DESCRIPTION (Version, Date): New release 0.4.18
+	* R/arrays.R:  Switch rgl::rgl.* to rgl::*3d functions
+	* demo/OptionSurfaces.R: Idem
+
 2022-10-25  Dirk Eddelbuettel  <edd@debian.org>
 
         * DESCRIPTION (Version, Date): New release 0.4.17

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,5 @@
 2023-01-06  Duncan Murdoch     <murdoch.duncan@gmail.com>
 
-        * DESCRIPTION (Version, Date): New release 0.4.18
 	* R/arrays.R:  Switch rgl::rgl.* to rgl::*3d functions
 	* demo/OptionSurfaces.R: Idem
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: RQuantLib
 Title: R Interface to the 'QuantLib' Library
-Version: 0.4.18
-Date: 2023-01-06
+Version: 0.4.17
+Date: 2022-10-25
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Author: Dirk Eddelbuettel, Khanh Nguyen (2009-2010), Terry Leitch (since 2016)
 Description: The 'RQuantLib' package makes parts of 'QuantLib' accessible from R

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ Description: The 'RQuantLib' package makes parts of 'QuantLib' accessible from R
  for quantitative finance. The goal is to provide a standard open source library
  for quantitative analysis, modeling, trading, and risk management of financial
  assets.
-Suggests: tinytest, rgl, shiny
+Suggests: tinytest, rgl (>= 0.111.5), shiny
 Imports: methods, Rcpp (>= 0.11.0), stats, graphics, zoo
 LinkingTo: Rcpp
 SystemRequirements: QuantLib library (>= 1.14) from https://quantlib.org,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: RQuantLib
 Title: R Interface to the 'QuantLib' Library
-Version: 0.4.17
-Date: 2022-10-25
+Version: 0.4.18
+Date: 2023-01-06
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Author: Dirk Eddelbuettel, Khanh Nguyen (2009-2010), Terry Leitch (since 2016)
 Description: The 'RQuantLib' package makes parts of 'QuantLib' accessible from R
@@ -9,7 +9,7 @@ Description: The 'RQuantLib' package makes parts of 'QuantLib' accessible from R
  for quantitative finance. The goal is to provide a standard open source library
  for quantitative analysis, modeling, trading, and risk management of financial
  assets.
-Suggests: tinytest, rgl (>= 0.111.5), shiny
+Suggests: tinytest, rgl, shiny
 Imports: methods, Rcpp (>= 0.11.0), stats, graphics, zoo
 LinkingTo: Rcpp
 SystemRequirements: QuantLib library (>= 1.14) from https://quantlib.org,

--- a/R/arrays.R
+++ b/R/arrays.R
@@ -128,36 +128,39 @@ plotOptionSurface <- function(EOres, ylabel="", xlabel="", zlabel="", fov=60) {
         rgl::bg3d(color="#DDDDDD")
         rgl::light3d()
 
-        rgl::rgl.viewpoint(fov=fov)
+        rgl::view3d(fov=fov)
 
         x <- 1:nrow(y)
         z <- 1:ncol(y)
         x <- (x-min(x))/(max(x)-min(x))
         y <- (y-min(y))/(max(y)-min(y))
         z <- (z-min(z))/(max(z)-min(z))
-        rgl::rgl.surface(x, z, y, alpha=0.6, lit=TRUE, color="blue")
-        rgl::rgl.lines(c(0,1), c(0,0), c(0,0), col=axis.col)
-        rgl::rgl.lines(c(0,0), c(0,1), c(0,0), col=axis.col)
-        rgl::rgl.lines(c(0,0),c(0,0), c(0,1), col=axis.col)
-        rgl::rgl.texts(1,0,0, xlab, adj=1, col=text.col)
-        rgl::rgl.texts(0,1,0, ylab, adj=1, col=text.col)
-        rgl::rgl.texts(0,0,1, zlab, adj=1, col=text.col)
+        
+        # NOT RIGHT:  spike is in the wrong direction.
+        
+        rgl::surface3d(x = x, y = y, z = z, alpha=0.6, lit=TRUE, color="blue")
+        rgl::lines3d(c(0,1), c(0,0), c(0,0), col=axis.col)
+        rgl::lines3d(c(0,0), c(0,1), c(0,0), col=axis.col)
+        rgl::lines3d(c(0,0),c(0,0), c(0,1), col=axis.col)
+        rgl::text3d(1,0,0, xlab, adj=1, col=text.col)
+        rgl::text3d(0,1,0, ylab, adj=1, col=text.col)
+        rgl::text3d(0,0,1, zlab, adj=1, col=text.col)
 
         ## add grid (credit's to John Fox scatter3d)
         xgridind <- round(seq(1, nrow(y), length=25))
         zgridind <- round(seq(1, ncol(y), length=25))
-        rgl::rgl.surface(x[xgridind], z[zgridind], y[xgridind,zgridind],
+        rgl::surface3d(x = x[xgridind], y = y[xgridind,zgridind], z = z[zgridind],
                          color="darkgray", alpha=0.5, lit=TRUE,
                          front="lines", back="lines")
 
-        ## animate (credit to rgl.viewpoint() example)
+        ## animate (credit to view3d() example)
         start <- proc.time()[3]
         while ((i <- 36*(proc.time()[3]-start)) < 360) {
-            rgl::rgl.viewpoint(i,i/8);
+            rgl::view3d(i,i/8);
         }
     } else {
         message("Please install the 'rgl' package before using this function.")
     }
 }
 
-utils::globalVariables(c("clear3d", "bg3d", "ligh3d", "rgl.viewpoint", "rgl.surface", "tgl.texts"))
+utils::globalVariables(c("clear3d", "bg3d", "ligh3d", "view3d", "surface3d", "text3d"))

--- a/R/arrays.R
+++ b/R/arrays.R
@@ -112,6 +112,10 @@ EuropeanOptionArrays <- function(type, underlying, strike, dividendYield,
 
 plotOptionSurface <- function(EOres, ylabel="", xlabel="", zlabel="", fov=60) {
     if (requireNamespace("rgl", quietly=TRUE)) {
+        if (packageVersion("rgl") < "0.111.5")
+            surface3d <- rgl::rgl.surface
+        else
+            surface3d <- rgl::surface3d
         axis.col <- "black"
         text.col <- axis.col
         ylab <- ylabel
@@ -136,9 +140,7 @@ plotOptionSurface <- function(EOres, ylabel="", xlabel="", zlabel="", fov=60) {
         y <- (y-min(y))/(max(y)-min(y))
         z <- (z-min(z))/(max(z)-min(z))
         
-        # NOT RIGHT:  spike is in the wrong direction.
-        
-        rgl::surface3d(x = x, y = y, z = z, alpha=0.6, lit=TRUE, color="blue")
+        surface3d(x = x, y = y, z = z, alpha=0.6, lit=TRUE, color="blue")
         rgl::lines3d(c(0,1), c(0,0), c(0,0), col=axis.col)
         rgl::lines3d(c(0,0), c(0,1), c(0,0), col=axis.col)
         rgl::lines3d(c(0,0),c(0,0), c(0,1), col=axis.col)
@@ -149,7 +151,7 @@ plotOptionSurface <- function(EOres, ylabel="", xlabel="", zlabel="", fov=60) {
         ## add grid (credit's to John Fox scatter3d)
         xgridind <- round(seq(1, nrow(y), length=25))
         zgridind <- round(seq(1, ncol(y), length=25))
-        rgl::surface3d(x = x[xgridind], y = y[xgridind,zgridind], z = z[zgridind],
+        surface3d(x = x[xgridind], y = y[xgridind,zgridind], z = z[zgridind],
                          color="darkgray", alpha=0.5, lit=TRUE,
                          front="lines", back="lines")
 

--- a/demo/OptionSurfaces.R
+++ b/demo/OptionSurfaces.R
@@ -21,36 +21,36 @@ OptionSurface <- function(EOres, label, fov=60) {
     bg3d(color="#DDDDDD")
     light3d()
 
-    rgl.viewpoint(fov=fov)
-    ##rgl.bg(col="white", fogtype="exp2")
-    ##rgl.bg(col="black", fogtype="exp2")
-    ##rgl.bg(col="black", fogtype="exp")
-    ##rgl.bg(col="white", fogtype="exp")
+    view3d(fov=fov)
+    ##bg3d(col="white", fogtype="exp2")
+    ##bg3d(col="black", fogtype="exp2")
+    ##bg3d(col="black", fogtype="exp")
+    ##bg3d(col="white", fogtype="exp")
 
     x <- (1:nrow(y))
     z <- (1:ncol(y))
     x <- (x-min(x))/(max(x)-min(x))
     y <- (y-min(y))/(max(y)-min(y))
     z <- (z-min(z))/(max(z)-min(z))
-    rgl.surface(x, z, y, alpha=0.6, lit=TRUE, color="blue")
-    rgl.lines(c(0,1), c(0,0), c(0,0), col=axis.col)
-    rgl.lines(c(0,0), c(0,1), c(0,0), col=axis.col)
-    rgl.lines(c(0,0),c(0,0), c(0,1), col=axis.col)
-    rgl.texts(1,0,0, xlab, adj=1, col=text.col)
-    rgl.texts(0,1,0, ylab, adj=1, col=text.col)
-    rgl.texts(0,0,1, zlab, adj=1, col=text.col)
+    surface3d(x, y, z, alpha=0.6, lit=TRUE, color="blue")
+    lines3d(c(0,1), c(0,0), c(0,0), col=axis.col)
+    lines3d(c(0,0), c(0,1), c(0,0), col=axis.col)
+    lines3d(c(0,0),c(0,0), c(0,1), col=axis.col)
+    text3d(1,0,0, xlab, adj=1, col=text.col)
+    text3d(0,1,0, ylab, adj=1, col=text.col)
+    text3d(0,0,1, zlab, adj=1, col=text.col)
 
     ## add grid (credit's to John Fox scatter3d)
     xgridind <- round(seq(1, nrow(y), length=25))
     zgridind <- round(seq(1, ncol(y), length=25))
-    rgl.surface(x[xgridind], z[zgridind], y[xgridind,zgridind],
+    surface3d(x[xgridind], y[xgridind,zgridind], z[zgridind], 
                 color="darkgray", alpha=0.5, lit=TRUE,
                 front="lines", back="lines")
 
-    ## animate (credit to rgl.viewpoint() example)
+    ## animate (credit to view3d() example)
     start <- proc.time()[3]
     while ((i <- 36*(proc.time()[3]-start)) < 360) {
-        rgl.viewpoint(i,i/8);
+        view3d(i,i/8);
     }
 }
 
@@ -65,7 +65,7 @@ RQuantLib.demo.OptionSurfaces <- function() {
                                   maturity = 1, volatility = vol.seq)
     cat(" done.\n")
 
-    rgl.open()
+    open3d()
     OptionSurface(EOarr$value, "Value")
     OptionSurface(EOarr$delta, "Delta")
     OptionSurface(EOarr$gamma, "Gamma")

--- a/demo/OptionSurfaces.R
+++ b/demo/OptionSurfaces.R
@@ -4,6 +4,11 @@
 ## $Id: OptionSurfaces.R,v 1.1 2005/10/12 03:42:45 edd Exp $
 
 OptionSurface <- function(EOres, label, fov=60) {
+    #
+    # This can be removed when rgl 0.111.5 is released:
+    if (packageVersion("rgl") < "0.111.5")
+      surface3d <- rgl.surface
+    # End of old workaround
     axis.col <- "black"
     text.col <- axis.col
     ylab <- label
@@ -32,7 +37,7 @@ OptionSurface <- function(EOres, label, fov=60) {
     x <- (x-min(x))/(max(x)-min(x))
     y <- (y-min(y))/(max(y)-min(y))
     z <- (z-min(z))/(max(z)-min(z))
-    surface3d(x, y, z, alpha=0.6, lit=TRUE, color="blue")
+    surface3d(x = x, y = y, z = z, alpha=0.6, lit=TRUE, color="blue")
     lines3d(c(0,1), c(0,0), c(0,0), col=axis.col)
     lines3d(c(0,0), c(0,1), c(0,0), col=axis.col)
     lines3d(c(0,0),c(0,0), c(0,1), col=axis.col)
@@ -43,9 +48,9 @@ OptionSurface <- function(EOres, label, fov=60) {
     ## add grid (credit's to John Fox scatter3d)
     xgridind <- round(seq(1, nrow(y), length=25))
     zgridind <- round(seq(1, ncol(y), length=25))
-    surface3d(x[xgridind], y[xgridind,zgridind], z[zgridind], 
-                color="darkgray", alpha=0.5, lit=TRUE,
-                front="lines", back="lines")
+    surface3d(x = x[xgridind], y = y[xgridind,zgridind], z = z[zgridind], 
+              color="darkgray", alpha=0.5, lit=TRUE,
+              front="lines", back="lines")
 
     ## animate (credit to view3d() example)
     start <- proc.time()[3]


### PR DESCRIPTION
The surface3d() function needs an rgl fix that's in the about-to-be-submitted version 0.111.5, so I've added that version requirement.  Let me know if you'd prefer a run-time test and workaround for the old code.