### PR TITLE
CI: download quantlib on macos if not found locally

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         include:
-          #- {os: macOS-latest}
+          - {os: macOS-latest}
           - {os: ubuntu-latest}
 
     runs-on: ${{ matrix.os }}
@@ -30,9 +30,11 @@ jobs:
         run: ./run.sh bootstrap
 
       - name: Dependencies
-        run: |
-          ./run.sh install_deps
-          ./run.sh install_aptget libquantlib0-dev libboost-dev
+        run: ./run.sh install_deps
+
+      - name: Linux Dependencies
+        if: runner.os == 'linux'
+        run: ./run.sh install_aptget libquantlib0-dev libboost-dev
 
       - name: Test
         run: ./run.sh run_tests

--- a/configure
+++ b/configure
@@ -3349,6 +3349,31 @@ printf "%s\n" "$as_me: WARNING: RQuantLib requires QuantLib (>= 1.14)." >&2;}
 
     LDFLAGS="${LDFLAGS} $pkg_libs"
 
+elif test "`uname`" == "Darwin" ; then
+  if test "`arch`" == "arm64" ; then
+    quantlib="https://mac.r-project.org/bin/darwin20/arm64/QuantLib-1.27.1-darwin.20-arm64.tar.xz"
+    boost="https://mac.r-project.org/bin/darwin20/arm64/boost-1.80.0-darwin.20-arm64.tar.xz"
+  else
+    quantlib="https://mac.r-project.org/bin/darwin20/x86_64/QuantLib-1.27.1-darwin.20-x86_64.tar.xz"
+    boost="https://mac.r-project.org/bin/darwin20/x86_64/boost-1.80.0-darwin.20-x86_64.tar.xz"
+  fi
+  quantlibdir="$PWD/.deps"
+  mkdir -p $quantlibdir
+  echo "downloading $quantlib"
+  curl -sSL "$quantlib" -o quantlib.tar.xz
+  echo "downloading $boost"
+  curl -sSL "$boost" -o boost.tar.xz
+  tar xf quantlib.tar.xz --strip 3 -C "$quantlibdir"
+  tar xf boost.tar.xz --strip 3 -C "$quantlibdir"
+  rm quantlib.tar.xz boost.tar.xz
+  pkg_cxxflags="-I${quantlibdir}/include"
+  pkg_libs="-L${quantlibdir}/lib -lQuantLib"
+
+  # Same as above
+  CXXFLAGS="${CXXFLAGS} $pkg_cxxflags"
+
+  LDFLAGS="${LDFLAGS} $pkg_libs"
+
 else
     as_fn_error $? "Please install QuantLib before trying to build RQuantLib." "$LINENO" 5
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -89,6 +89,29 @@ if test x"${QUANTLIB}" == x"yes" ; then
     AC_SUBST([CXXFLAGS],["${CXXFLAGS} "])
     AC_SUBST([CXXFLAGS],["${CXXFLAGS} ${pkg_cxxflags} ${gxx_newer_than_45}"])
     AC_SUBST([LDFLAGS],["${LDFLAGS} $pkg_libs"])
+elif test "`uname`" == "Darwin" ; then
+  if test "`arch`" == "arm64" ; then
+    quantlib="https://mac.r-project.org/bin/darwin20/arm64/QuantLib-1.27.1-darwin.20-arm64.tar.xz"
+    boost="https://mac.r-project.org/bin/darwin20/arm64/boost-1.80.0-darwin.20-arm64.tar.xz"
+  else
+    quantlib="https://mac.r-project.org/bin/darwin20/x86_64/QuantLib-1.27.1-darwin.20-x86_64.tar.xz"
+    boost="https://mac.r-project.org/bin/darwin20/x86_64/boost-1.80.0-darwin.20-x86_64.tar.xz"
+  fi
+  quantlibdir="$PWD/.deps"
+  mkdir -p $quantlibdir
+  echo "downloading $quantlib"
+  curl -sSL "$quantlib" -o quantlib.tar.xz
+  echo "downloading $boost"
+  curl -sSL "$boost" -o boost.tar.xz
+  tar xf quantlib.tar.xz --strip 3 -C "$quantlibdir"
+  tar xf boost.tar.xz --strip 3 -C "$quantlibdir"
+  rm quantlib.tar.xz boost.tar.xz
+  pkg_cxxflags="-I${quantlibdir}/include"
+  pkg_libs="-L${quantlibdir}/lib -lQuantLib"
+
+  # Same as above
+  AC_SUBST([CXXFLAGS],["${CXXFLAGS} $pkg_cxxflags"])
+  AC_SUBST([LDFLAGS],["${LDFLAGS} $pkg_libs"])
 else
     AC_MSG_ERROR([Please install QuantLib before trying to build RQuantLib.])
 fi

--- a/inst/tinytest/test_dates.R
+++ b/inst/tinytest/test_dates.R
@@ -1,7 +1,7 @@
 
-.onWindows <- .Platform$OS.type == "windows"
+.onWinOrMac <- grepl("darwin|mingw", R.Version()$platform)
 
-if (.onWindows) exit_file("Skipping dates test on Windows.")
+if (.onWinOrMac) exit_file("Skipping dates test on Windows.")
 
 Rcpp::sourceCpp("cpp/dates.cpp")
 


### PR DESCRIPTION
This will allow the package to be built in CI or r-universe or by mac users locally, with the same quantlib as CRAN.

On systems where `quantlib-config` is found (such as cran itself), that configuration is used, and nothing is downloaded. So it functions as a fallback method for mac systems where quantlib is not available.

PS: if you use this, I recommend mirroring the downloaded files from cran somewhere (e.g. github release assets) because `mac.r-project.org` is pretty slow and flaky.


