### PR TITLE
Windows: update to quantlib 1.29

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -6,19 +6,10 @@
 # Copyright 2011         Uwe Ligges, Brian Ripley, and Josh Ulrich
 # Copyright 2018 - 2019  Jeroen Ooms
 
-RWINLIB=../windows/quantlib-1.16
+RWINLIB=../windows/quantlib-1.29
 PKG_CPPFLAGS=-I$(RWINLIB)/include -I../inst/include
 PKG_CXXFLAGS=$(SHLIB_OPENMP_CXXFLAGS) -DBOOST_NO_AUTO_PTR -Wno-deprecated-declarations
-## NB directory layout with arch/lib is quantlib upstream default which is followed here
-
-TARGET = $(subst gcc,lib,$(COMPILED_BY))
-PKG_LIBS = \
-	-L$(RWINLIB)/$(TARGET)$(R_ARCH)/lib \
-	-L$(RWINLIB)/lib$(R_ARCH)/lib \
-	-lQuantLib $(SHLIB_OPENMP_CXXFLAGS)
-
-# Use C++14 with QuantLib 1.28 or later -- and the default with R 4.2.* anyway
-CXX_STD=CXX14
+PKG_LIBS = -L$(RWINLIB)/lib$(R_ARCH) -lQuantLib
 
 all: clean winlibs
 

--- a/tools/winlibs.R
+++ b/tools/winlibs.R
@@ -1,16 +1,8 @@
 # Build against mingw-w64 build of quantlib
-if (!file.exists("../windows/quantlib-1.16/include/ql/quantlib.hpp")) {
-  if (getRversion() < "3.3.0") setInternet2()
-  download.file("https://github.com/rwinlib/quantlib/archive/v1.16.zip", "quantlib-1.16.zip", quiet = TRUE)
+if (!file.exists("../windows/quantlib-1.29/include/ql/quantlib.hpp")) {
+  download.file("https://github.com/rwinlib/quantlib/archive/v1.29.zip", "quantlib-1.29.zip", quiet = TRUE)
   dir.create("../windows", showWarnings = FALSE)
-  unzip("quantlib-1.16.zip", exdir = "../windows")
-  unlink("quantlib-1.16.zip")
-  
-  # Static libraries for the told toolchain
-  unzip("../windows/quantlib-1.16/lib-4.9.3.zip", exdir = "../windows/quantlib-1.16")
-  
-  # Static libraries for the new toolchain
-  if (getRversion() > "3.6.99"){
-    unzip("../windows/quantlib-1.16/lib.zip", exdir = "../windows/quantlib-1.16")
-  }
+  unzip("quantlib-1.29.zip", exdir = "../windows")
+  unlink("quantlib-1.29.zip")
+  unzip("../windows/quantlib-1.29/lib.zip", exdir = "../windows/quantlib-1.29")
 }


### PR DESCRIPTION
I'm guessing you're going to need this to get your next release past the cran winbuilder as well.