### PR TITLE
Use quantlib from the system when available via pkg-config.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2024-03-25  Tomas Kalibera  <tomas.kalibera@gmail.com>
+
+	* src/Makevars.win: Preferentially use QuantLib from the system if
+	  found via pkg-config (prepare for upcoming Rtools)
+
 2025-03-24  Dirk Eddelbuettel  <edd@debian.org>
 
         * DESCRIPTION (Version, Date): New release 0.4.25

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -6,10 +6,17 @@
 # Copyright 2011         Uwe Ligges, Brian Ripley, and Josh Ulrich
 # Copyright 2018 - 2024  Jeroen Ooms
 
-RWINLIB=../windows/quantlib
-PKG_CPPFLAGS=-I$(RWINLIB)/include -I../inst/include
-PKG_CXXFLAGS=-DBOOST_NO_AUTO_PTR
-PKG_LIBS = -L$(RWINLIB)/lib$(R_ARCH) -L$(RWINLIB)/lib -lQuantLib
+PKG_CPPFLAGS = $(shell pkg-config --cflags quantlib 2>/dev/null)
+PKG_LIBS = $(shell pkg-config --libs quantlib 2>/dev/null)
+
+ifeq ($(PKG_LIBS),)
+  RWINLIB = ../windows/quantlib
+  PKG_CPPFLAGS = -I$(RWINLIB)/include
+  PKG_LIBS = -L$(RWINLIB)/lib$(R_ARCH) -L$(RWINLIB)/lib -lQuantLib
+endif
+
+PKG_CPPFLAGS += -I../inst/include
+PKG_CXXFLAGS = -DBOOST_NO_AUTO_PTR
 
 all: clean winlibs
 
@@ -17,4 +24,7 @@ clean:
 	rm -f $(SHLIB) $(OBJECTS)
 
 winlibs:
+ifneq ($(RWINLIB),)
 	"${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" "../tools/winlibs.R"
+endif
+


### PR DESCRIPTION
This changes Makevars.win to use QuantLib on Windows from the system when available via pkg-config, otherwise falling back to what has been done before. This will allow using QuantLib from Rtools - it will be available there from the next update. The package passes its checks with QuantLib in the development version of Rtools on my system.